### PR TITLE
Minor fixes.

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :satellite,
-  origin: "foo",
+  origin: "satellite",
   handler:
     {Satellite.Handler.Redis,
      connection: [
@@ -10,19 +10,17 @@ config :satellite,
      ],
      name: :test_name},
   bridge: %{
-    services: [],
+    services: [IdentityProcessor],
     sink:
       {Satellite.Bridge.Sink.Kinesis,
        kinesis_role_arn: 1, kinesis_stream_name: "foo_stream", assume_role_region: "eu-west-1"},
     source:
       {Satellite.Bridge.Source.Redis,
        connection: [host: "127.0.0.1", port: 6379], channels: ["robot:*", "user:*"]},
-    processors_concurrency: 1,
+    processors_concurrency: 2,
     batchers: [
-      concurrency: 1,
+      concurrency: 2,
       batch_size: 1,
       batch_timeout: 5000
     ]
-  },
-  producer_module: Broadway.DummyProducer,
-  producer_options: []
+  }

--- a/lib/satellite/bridge.ex
+++ b/lib/satellite/bridge.ex
@@ -33,7 +33,7 @@ defmodule Satellite.Bridge do
       },
       producer: [
         module: {source, source_opts},
-        concurrency: concurrency
+        concurrency: 1
       ],
       processors: [
         default: [
@@ -131,6 +131,16 @@ defmodule Satellite.Bridge do
 
   defp apply_service(%{data: data}, service) do
     apply(service, :process, [data])
+    |> case do
+      {:ok, event} ->
+        {:ok, %{data: event}}
+
+      {:ok, event, metadata} ->
+        {:ok, %{data: event, metadata: metadata}}
+
+      error ->
+        error
+    end
   end
 
   @spec encode_data(map()) :: {:ok, map()} | {:error, term()}

--- a/lib/satellite/bridge/processor_behaviour.ex
+++ b/lib/satellite/bridge/processor_behaviour.ex
@@ -6,5 +6,8 @@ defmodule Satellite.Bridge.ProcessorBehaviour do
   Source -> [Transformations] -> Sink
   """
 
-  @callback process(term) :: {:ok, term()} | {:error, term()}
+  @callback process(term) ::
+              {:ok, event :: term()}
+              | {:ok, event :: term(), metadata :: map()}
+              | {:error, :atom}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Satellite.MixProject do
   def project do
     [
       app: :satellite,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.14",
       dialyzer: dialyzer(),
       start_permanent: Mix.env() == :prod,

--- a/test/bridge/integration/redis2kinesis.exs
+++ b/test/bridge/integration/redis2kinesis.exs
@@ -1,0 +1,24 @@
+defmodule Bridge.Integration.Redis2SQSTest do
+  use ExUnit.Case
+  import Mock
+
+  alias Satellite.Bridge.Sink.Kinesis
+  alias Satellite.Handler
+  alias Satellite.Event
+
+  describe "event processing" do
+    test "it only processes events once" do
+      with_mock Kinesis, [:passthrough],
+        send: fn _message, _opts ->
+          :ok
+        end do
+        event1 = Event.new(%{type: "foo", origin: "robot", payload: %{a: 1}})
+        Handler.Redis.send(event1)
+
+        :timer.sleep(1_000)
+
+        assert_called_exactly(Kinesis.send(:_, :_), 1)
+      end
+    end
+  end
+end

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -8,7 +8,7 @@ defmodule Satellite.EventTest do
       event = Event.new(%{type: "test", payload: %{a: 1}})
 
       assert event.timestamp
-      assert %Event{origin: "foo", version: 1, type: "test", payload: %{a: 1}} = event
+      assert %Event{origin: "satellite", version: 1, type: "test", payload: %{a: 1}} = event
     end
 
     test "it can override default values" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,15 +5,15 @@ defmodule Double do
 end
 
 defmodule DoubleWithMetadata do
-  def process(x), do: {:ok, %{data: 2 * x, metadata: %{foo: x}}}
+  def process(x), do: {:ok, 2 * x, %{foo: x}}
 end
 
 defmodule TripleWithMetadata do
-  def process(x), do: {:ok, %{data: 3 * x, metadata: %{bar: x}}}
+  def process(x), do: {:ok, 3 * x, %{bar: x}}
 end
 
 defmodule IdentityProcessor do
-  def process(x), do: {:ok, %{data: x}}
+  def process(x), do: {:ok, x}
 end
 
 defmodule Fail do


### PR DESCRIPTION
* Ensure data is wrapped properly before attempting to merge metadata
* Always use concurrency 1 for broadway producers to avoid processing events twice